### PR TITLE
Removing call to the deprecated parseQuery function. Using getOptions…

### DIFF
--- a/common/changes/ianc-parsequery_2017-02-27-22-30.json
+++ b/common/changes/ianc-parsequery_2017-02-27-22-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/loader-set-webpack-public-path",
+      "comment": "Removing call to the deprecated parseQuery function. Using getOptions instead.",
+      "type": "patch"
+    }
+  ],
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/loader-set-webpack-public-path/src/SetWebpackPublicPathLoader.ts
+++ b/loader-set-webpack-public-path/src/SetWebpackPublicPathLoader.ts
@@ -50,7 +50,7 @@ export class SetWebpackPublicPathLoader {
   }
 
   private static getOptions(query: string): IInternalOptions {
-    const queryOptions: ISetWebpackPublicPathLoaderOptions = loaderUtils.parseQuery(query);
+    const queryOptions: ISetWebpackPublicPathLoaderOptions = loaderUtils.getOptions(query);
 
     const options: ISetWebpackPublicPathLoaderOptions & IInternalOptions =
       merge(merge({}, SetWebpackPublicPathLoader.staticOptions), queryOptions);


### PR DESCRIPTION
… instead.